### PR TITLE
Create a standardized snackbar for errors

### DIFF
--- a/src/containers/ErrorSnackbar.js
+++ b/src/containers/ErrorSnackbar.js
@@ -1,0 +1,30 @@
+import {
+  clearMessage,
+  getSnackbarErrorMessage,
+} from 'data/snackbarErrorMessage'
+import { connect } from 'react-redux'
+import Snackbar from 'material-ui/Snackbar'
+import injectSheet from 'react-jss'
+
+const styles = ({ palette }) => ({
+  root: {
+    backgroundColor: palette.error.dark,
+    color: palette.getContrastText(palette.error.dark),
+  },
+})
+
+const mapStateToProps = (state, props) => ({
+  SnackbarContentProps: { className: props.classes.root },
+  message: getSnackbarErrorMessage(state),
+  open: !!getSnackbarErrorMessage(state),
+})
+
+const mapDispatchToProps = {
+  onClose: clearMessage,
+}
+
+// NOTE(adam): must connect first for classes to exist in mapStateToProps
+const ErrorConnectedSnackbar = connect(mapStateToProps, mapDispatchToProps)(
+  Snackbar,
+)
+export default injectSheet(styles)(ErrorConnectedSnackbar)

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -26,6 +26,9 @@ export const fetchEventsFailed = error => ({
   type: FETCH_EVENTS_FAILED,
   payload: error,
   error: true,
+  meta: {
+    message: 'Could not get events.',
+  },
 })
 
 // REDUCER

--- a/src/data/snackbarErrorMessage.js
+++ b/src/data/snackbarErrorMessage.js
@@ -1,0 +1,19 @@
+import createReducer from 'utils/createReducer'
+
+// ACTIONS
+export const SET_MESSAGE = 'snackbarErrorMessage/SET_MESSAGE'
+export const CLEAR_MESSAGE = 'snackbarErrorMessage/CLEAR_MESSAGE'
+
+// ACTION CREATORS
+export const setMessage = message => ({ type: SET_MESSAGE, payload: message })
+export const clearMessage = () => ({ type: CLEAR_MESSAGE })
+
+// REDUCER
+export default createReducer(null, {
+  [SET_MESSAGE]: (_state, { payload: message }) => message,
+  [CLEAR_MESSAGE]: _state => null,
+})
+
+// SELECTORS
+export const getSnackbarErrorMessage = state =>
+  state.get('snackbarErrorMessage')

--- a/src/epics/errorSnackbar.js
+++ b/src/epics/errorSnackbar.js
@@ -1,0 +1,24 @@
+import {
+  SET_MESSAGE,
+  clearMessage,
+  setMessage,
+} from 'data/snackbarErrorMessage'
+import { combineEpics } from 'redux-observable'
+import { isError } from 'utils/actions'
+
+const messageTimeout = 5000
+
+const setErrorMesage = action$ =>
+  action$
+    .filter(isError)
+    .filter(action => action.meta.message)
+    .map(action => action.meta.message)
+    .map(setMessage)
+
+const clearErrorMessage = action$ =>
+  action$
+    .ofType(SET_MESSAGE)
+    .mapTo(clearMessage())
+    .delay(messageTimeout)
+
+export default combineEpics(setErrorMesage, clearErrorMessage)

--- a/src/middleware/errorLogger.js
+++ b/src/middleware/errorLogger.js
@@ -1,10 +1,6 @@
 // NOTE(adam): provides automatic logging of error actions
 const logger = _store => next => action => {
   if (action.error) {
-    /* TODO(adam): add snackbar error displaying
-     * see https://medium.com/@jacobp100/you-arent-using-redux-middleware-enough-94ffe991e6
-     * could include message in meta tag with flag for api calls / snackbar triggers
-     */
     console.error('Error action occured', action) // eslint-disable-line no-console
   }
   next(action)

--- a/src/root.js
+++ b/src/root.js
@@ -1,12 +1,15 @@
 import { combineEpics } from 'redux-observable'
 import { combineReducers } from 'redux-immutable'
+import errorSnackbar from 'epics/errorSnackbar'
 import events, { fetchEventsEpic } from 'data/events'
 import isFetchingEvents from 'data/isFetchingEvents'
 import navigation from 'epics/navigation'
+import snackbarErrorMessage from 'data/snackbarErrorMessage'
 
-export const rootEpic = combineEpics(fetchEventsEpic, navigation)
+export const rootEpic = combineEpics(fetchEventsEpic, navigation, errorSnackbar)
 
 export const rootReducer = combineReducers({
   events,
   isFetchingEvents,
+  snackbarErrorMessage,
 })

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -1,0 +1,5 @@
+export const payload = action => action.payload
+
+export const meta = action => action.meta
+
+export const isError = action => action.error

--- a/src/views/EventsPage.js
+++ b/src/views/EventsPage.js
@@ -1,4 +1,5 @@
 import Donate from 'components/Donate'
+import ErrorSnackbar from 'containers/ErrorSnackbar'
 import EventList from 'containers/EventListWithFetch'
 import Header from 'components/Header'
 import PropTypes from 'utils/propTypes'
@@ -27,6 +28,7 @@ const EventPage = ({ classes }) => (
         <Donate />
       </Tile>
     </div>
+    <ErrorSnackbar />
   </div>
 )
 


### PR DESCRIPTION
To standardize the notification of errors, the errorSnackbar epic will
watch for error actions that have a message property in the meta object
and dispatch an action to show the messsage on the ErrorSnackbar. The
action to show a message is also watched for to later send an action to
clear the message.

While the snackbar is active, other errors are ignored because,
presumadly, they are a result of the current error being shown.

Potentially, an error action with a message may not want to display in
the ErrorSnackbar. Other flags could be added to the meta object for
filtering.

Closes #33 