### PR TITLE
Use rxjs for api calls

### DIFF
--- a/src/data/alumni.js
+++ b/src/data/alumni.js
@@ -1,5 +1,5 @@
 import { Map, Record } from 'immutable'
-import { Observable } from 'rxjs/Rx'
+import { Observable } from 'rxjs'
 import { createSelector } from 'reselect'
 import AlumniResource from 'resources/Alumni'
 import createReducer from 'utils/createReducer'
@@ -53,8 +53,8 @@ const mapData = data =>
 // EPICS
 export const fetchAlumniEpic = action$ =>
   action$.ofType(FETCH_ALUMNI).mergeMap(() =>
-    Observable.fromPromise(AlumniResource.getAll())
+    AlumniResource.getAll()
       .map(mapData)
       .map(fetchAlumniSucceeded)
-      .catch(fetchAlumniFailed),
+      .catch(e => Observable.of(fetchAlumniFailed(e))),
   )

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -1,5 +1,5 @@
 import { List, Record } from 'immutable'
-import { Observable } from 'rxjs/Rx'
+import { Observable } from 'rxjs'
 import Events from 'resources/Events'
 import createReducer from 'utils/createReducer'
 
@@ -41,29 +41,27 @@ export const getEvents = state => state.get('events')
 
 const mapData = data => List(data.map(Event))
 
-// API
-const apiFetchEvents = () =>
-  Events.getAll()
-    .then(() => [
-      {
-        name: 'Event Name',
-        description: 'Testing Things',
-        link: 'google.com',
-        startDate: '2018-03-01',
-      },
-      {
-        name: 'Event 2',
-        description: 'Testing more things',
-        link: 'google.com',
-        startDate: '2018-03-01',
-      },
-    ])
-    .then(mapData)
-    .then(fetchEventsSucceeded)
-    .catch(fetchEventsFailed)
+const dummyData = [
+  {
+    name: 'Event Name',
+    description: 'Testing Things',
+    link: 'google.com',
+    startDate: '2018-03-01',
+  },
+  {
+    name: 'Event 2',
+    description: 'Testing more things',
+    link: 'google.com',
+    startDate: '2018-03-01',
+  },
+]
 
 // EPICS
 export const fetchEventsEpic = action$ =>
-  action$
-    .ofType(FETCH_EVENTS)
-    .mergeMap(() => Observable.fromPromise(apiFetchEvents()))
+  action$.ofType(FETCH_EVENTS).mergeMap(() =>
+    Events.getAll()
+      .map(() => dummyData)
+      .map(mapData)
+      .map(fetchEventsSucceeded)
+      .catch(e => Observable.of(fetchEventsFailed(e))),
+  )

--- a/src/utils/request/request.js
+++ b/src/utils/request/request.js
@@ -1,4 +1,5 @@
 import { Record } from 'immutable'
+import { ajax } from 'rxjs/observable/dom/ajax'
 
 export const Conn = Record({
   service: null,
@@ -11,7 +12,7 @@ export const buildConnection = params => (conn = Conn()) =>
 
 const buildRequest = conn => {
   const { service, resource, ...connParams } = conn.toJS()
-  return new Request(`${service.url}${resource.url}`, { ...connParams })
+  return ajax({ ...connParams, url: `${service.url}${resource.url}` })
 }
 
 const keepIfNotNull = (a, b) => (b ? b : a)
@@ -28,5 +29,5 @@ export default connOrBuilder => {
       }. Only ${conn.resource.allowedMethods.toJS().join()} are allowed.`,
     )
 
-  return fetch(buildRequest(conn)).then(response => response.json())
+  return buildRequest(conn).map(({ response }) => response)
 }


### PR DESCRIPTION
Because rxjs natively includes a method of making api calls, using it
cleans up implementation details and allows staying in the observable
ecosystem.

Closes #51 