### PR TITLE
Add helper functions for data modules

### DIFF
--- a/src/data/alumni.js
+++ b/src/data/alumni.js
@@ -1,5 +1,6 @@
 import { Map, Record } from 'immutable'
 import { Observable } from 'rxjs'
+import { action, creator, errorCreator, get, replace } from 'utils/data'
 import { createSelector } from 'reselect'
 import AlumniResource from 'resources/Alumni'
 import createReducer from 'utils/createReducer'
@@ -16,33 +17,29 @@ export const Alumni = Record({
   isBoardMember: false,
 })
 
+// KEY
+export const key = 'alumni'
+
 // ACTIONS
-export const FETCH_ALUMNI = 'alumni/FETCH_ALUMNI'
-export const FETCH_ALUMNI_SUCCEEDED = 'alumni/FETCH_ALUMNI_SUCCEEDED'
-export const FETCH_ALUMNI_FAILED = 'alumni/FETCH_ALUMNI_FAILED'
+export const FETCH_ALUMNI = action(key, 'FETCH_ALUMNI')
+export const FETCH_ALUMNI_SUCCEEDED = action(key, 'FETCH_ALUMNI_SUCCEEDED')
+export const FETCH_ALUMNI_FAILED = action(key, 'FETCH_ALUMNI_FAILED')
 
 // ACTION CREATORS
-export const fetchAlumni = () => ({ type: FETCH_ALUMNI })
-export const fetchAlumniSucceeded = alumni => ({
-  type: FETCH_ALUMNI_SUCCEEDED,
-  payload: alumni,
-})
-export const fetchAlumniFailed = error => ({
-  type: FETCH_ALUMNI_FAILED,
-  payload: error,
-  error: true,
-  meta: {
-    message: 'Could not get alumni.',
-  },
-})
+export const fetchAlumni = creator(FETCH_ALUMNI)
+export const fetchAlumniSucceeded = creator(FETCH_ALUMNI_SUCCEEDED, 'alumni')
+export const fetchAlumniFailed = errorCreator(
+  FETCH_ALUMNI_FAILED,
+  'Could not get alumni.',
+)
 
 // REDUCER
 export default createReducer(Map(), {
-  [FETCH_ALUMNI_SUCCEEDED]: (_state, { payload: alumni }) => alumni,
+  [FETCH_ALUMNI_SUCCEEDED]: replace('alumni'),
 })
 
 // SELECTORS
-export const getAllAlumni = state => state.get('alumni')
+export const getAllAlumni = get('alumni')
 export const getBoardMembers = createSelector([getAllAlumni], alumni =>
   alumni.filter(a => a.isBoardMember),
 )

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -1,5 +1,6 @@
 import { List, Record } from 'immutable'
 import { Observable } from 'rxjs'
+import { action, creator, errorCreator, get, replace } from 'utils/data'
 import Events from 'resources/Events'
 import createReducer from 'utils/createReducer'
 
@@ -11,33 +12,29 @@ export const Event = Record({
   startDate: null,
 })
 
+// KEY
+export const key = 'events'
+
 // ACTIONS
-export const FETCH_EVENTS = 'events/FETCH_EVENTS'
-export const FETCH_EVENTS_SUCCEEDED = 'events/FETCH_EVENTS_SUCCEEDED'
-export const FETCH_EVENTS_FAILED = 'events/FETCH_EVENTS_FAILED'
+export const FETCH_EVENTS = action(key, 'FETCH_EVENTS')
+export const FETCH_EVENTS_SUCCEEDED = action(key, 'FETCH_EVENTS_SUCCEEDED')
+export const FETCH_EVENTS_FAILED = action(key, 'FETCH_EVENTS_FAILED')
 
 // ACTION CREATORS
-export const fetchEvents = () => ({ type: FETCH_EVENTS })
-export const fetchEventsSucceeded = events => ({
-  type: FETCH_EVENTS_SUCCEEDED,
-  payload: events,
-})
-export const fetchEventsFailed = error => ({
-  type: FETCH_EVENTS_FAILED,
-  payload: error,
-  error: true,
-  meta: {
-    message: 'Could not get events.',
-  },
-})
+export const fetchEvents = creator(FETCH_EVENTS)
+export const fetchEventsSucceeded = creator(FETCH_EVENTS_SUCCEEDED, 'events')
+export const fetchEventsFailed = errorCreator(
+  FETCH_EVENTS_FAILED,
+  'Could not get events.',
+)
 
 // REDUCER
 export default createReducer(List(), {
-  [FETCH_EVENTS_SUCCEEDED]: (_state, { payload: events }) => events,
+  [FETCH_EVENTS_SUCCEEDED]: replace('events'),
 })
 
 // SELECTORS
-export const getEvents = state => state.get('events')
+export const getEvents = get('events')
 
 const mapData = data => List(data.map(Event))
 

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,0 +1,70 @@
+/**
+ * A simple function for creating action strings.
+ *
+ * @param {string} key - the data key
+ * @param {string} name - the action name
+ * @returns {string} the formatted action string
+ */
+export const action = (key, name) => `${key}/${name}`
+
+/**
+ * A function that creates an action
+ * @typedef {function(...*):Action} ActionCreator
+ * @param {...*} args - values to be handled by the action
+ * @returns {Action} the action with the provided values
+ */
+
+/**
+ * Constructs an action creator
+ *
+ * @param {string} type - an action type
+ * @param {string[]} argNames - the names of arguments the creator will expect
+ * @param {Object} [context] - the contextual properties of the action
+ * @param {Object} context.meta - meta attributes for the action
+ * @param {boolean} context.error - a flag if the action represents an error
+ * @returns {ActionCreator} the constructed action creator
+ */
+const creatorBuilder = (type, argNames, { meta, error } = {}) => (...args) => {
+  if (argNames.lengh === 0) return { type, payload: null }
+
+  const payload = error
+    ? args[0]
+    : argNames.reduce((p, name, index) => ({ ...p, [name]: args[index] }), {})
+  return { type, payload, meta, error }
+}
+
+/**
+ * Builds a generic action creator
+ *
+ * @param {string} type - an action type
+ * @param {...*} [argNames] - names for the action creator's arguments
+ * @returns {ActionCreator} the constructed action creator
+ */
+export const creator = (type, ...argNames) => creatorBuilder(type, argNames)
+
+/**
+ * Builds an error action creator
+ *
+ * @param {string} type - an action type
+ * @param {string} message - the descriptive message for the error
+ * @returns {ActionCreator} the constructed action creator
+ */
+export const errorCreator = (type, message) =>
+  creatorBuilder(type, [], { error: true, meta: { message } })
+
+/**
+ * A reducer function to replace reducer state with the data in the action
+ *
+ * @param {string} key - the payload's data key
+ * @returns {function(*, Object.<string, *>):*} a function that returns the
+ * data at the specified key within the payload
+ */
+export const replace = key => (_state, { payload: { [key]: value } }) => value
+
+/**
+ * Create a selector that gets the data at key from state.
+ *
+ * @param {string} key - the data key
+ * @returns {function(State):*} the data at the key
+ */
+export const get = key => state => state.get(key)


### PR DESCRIPTION
With the repeated structure of data modules, helper functions will
reduce the repetition and boilerplate, resulting in simpler data module
code.

More helpers will be useful, but they will be created as needed.

Closes #64 