### PR TITLE
Remove travis caching node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
   - node
-cache:
-  directories:
-    - node_modules
 script:
   - npm test
   - npm run build


### PR DESCRIPTION
Travis runs `npm ci` which blows away node_modules.